### PR TITLE
Fix backward compatibility mode not working.

### DIFF
--- a/js/attrchange.js
+++ b/js/attrchange.js
@@ -53,7 +53,7 @@ https://github.com/meetselva/attrchange/blob/master/MIT-License.txt
 			|| window.WebKitMutationObserver;
 
 	$.fn.attrchange = function(a, b) {
-		if (typeof a == 'object') {//core
+		if (typeof a === 'object' || typeof a === 'function') {//core
 			var cfg = {
 				trackValues : false,
 				callback : $.noop


### PR DESCRIPTION
Can now use callback function as first param without wrapping in object.
